### PR TITLE
Add Swagger docs to endpoints

### DIFF
--- a/MyWebApp/Endpoints/GetImage.cs
+++ b/MyWebApp/Endpoints/GetImage.cs
@@ -14,6 +14,13 @@ public class GetImage : Endpoint<GetImageRequest>
     {
         Get("/api/image/{testId}/{imageName}");
         AllowAnonymous();
+        Summary(s =>
+        {
+            s.Summary = "Download a test image";
+            s.Description = "Retrieves the specified image associated with a test.";
+            s.Response(200, "Image stream");
+            s.Response(404, "Image not found");
+        });
     }
 
     public override async Task HandleAsync(GetImageRequest req, CancellationToken ct)

--- a/MyWebApp/Endpoints/GetTestById.cs
+++ b/MyWebApp/Endpoints/GetTestById.cs
@@ -16,6 +16,13 @@ public class GetTestById : Endpoint<GetTestByIdRequest, GetTestByIdResponse>
     {
         Get("/api/test/{Id}");
         AllowAnonymous();
+        Summary(s =>
+        {
+            s.Summary = "Get a single test";
+            s.Description = "Returns detailed information about a test by its identifier.";
+            s.Response<GetTestByIdResponse>(200, "The requested test");
+            s.Response(404, "Test not found");
+        });
     }
 
     public override async Task HandleAsync(GetTestByIdRequest req, CancellationToken ct)

--- a/MyWebApp/Endpoints/GetTests.cs
+++ b/MyWebApp/Endpoints/GetTests.cs
@@ -15,6 +15,13 @@ public class GetTests : EndpointWithoutRequest<GetTestsResponse>
     {
         Get("/api/test/list");
         AllowAnonymous();
+        Summary(s =>
+        {
+            s.Summary = "Get all tests";
+            s.Description = "Returns a list with basic information about every test.";
+            s.Response<GetTestsResponse>(200, "List of tests");
+            s.Response(404, "No tests were found");
+        });
     }
 
     public override async Task HandleAsync(CancellationToken ct)

--- a/MyWebApp/Endpoints/PostImage.cs
+++ b/MyWebApp/Endpoints/PostImage.cs
@@ -16,6 +16,12 @@ public class PostImage : Endpoint<PostImageRequest>
         Post("/api/image/{testId}/{imageName}");
         AllowFileUploads();
         AllowAnonymous();
+        Summary(s =>
+        {
+            s.Summary = "Upload a test image";
+            s.Description = "Uploads an image file for the specified test.";
+            s.Response(200, "Image uploaded successfully");
+        });
     }
 
     public override async Task HandleAsync(PostImageRequest req, CancellationToken ct)

--- a/MyWebApp/Endpoints/PostTest.cs
+++ b/MyWebApp/Endpoints/PostTest.cs
@@ -12,6 +12,12 @@ public class PostTest : EndpointWithoutRequest<Guid>
     {
         Post("/api/test");
         AllowAnonymous();
+        Summary(s =>
+        {
+            s.Summary = "Create a sample test";
+            s.Description = "Creates a test with placeholder data and returns its identifier.";
+            s.Response<Guid>(201, "Identifier of the new test");
+        });
     }
 
     public override async Task HandleAsync(CancellationToken ct)

--- a/MyWebApp/Endpoints/PutTest.cs
+++ b/MyWebApp/Endpoints/PutTest.cs
@@ -14,6 +14,13 @@ public class PutTest : Endpoint<PutTestRequest>
     {
         Put("/api/test/{Id}");
         AllowAnonymous();
+        Summary(s =>
+        {
+            s.Summary = "Update a test";
+            s.Description = "Updates an existing test with the provided data.";
+            s.Response(204, "Test updated successfully");
+            s.Response(404, "Test or tag not found");
+        });
     }
 
     public override async Task HandleAsync(PutTestRequest req, CancellationToken ct)

--- a/MyWebApp/Program.cs
+++ b/MyWebApp/Program.cs
@@ -6,11 +6,15 @@ using Repository.S3;
 
 var bld = WebApplication.CreateBuilder(args);
 bld.Services.AddFastEndpoints();
+bld.Services.AddEndpointsApiExplorer();
+bld.Services.AddSwaggerGen();
 bld.Services.AddScoped<OaDbContext>();
 bld.Services.AddScoped<RepositoryManager>();
 bld.Services.AddScoped<ITestImageRepository, TestImageMockRepository>();
 //bld.Services.AddSingleton<ILogger, MyWebApp.Logger>();
 
 var app = bld.Build();
+app.UseSwagger();
+app.UseSwaggerUI();
 app.UseFastEndpoints();
 app.Run();


### PR DESCRIPTION
## Summary
- add Swagger services and middleware
- document all API endpoints using FastEndpoints `Summary`

## Testing
- `dotnet build MyWebApp/MyWebApp.csproj -v q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eb5ff5e1483208c9e7fa41979177f