### PR TITLE
Make image repository configurable in tests

### DIFF
--- a/MyWebApp.Tests/EndpointTests.cs
+++ b/MyWebApp.Tests/EndpointTests.cs
@@ -139,7 +139,7 @@ public class EndpointTests
     public async Task GetImage_Returns_File()
     {
         var repoManager = TestHelper.CreateRepositoryManager(out _);
-        var imgRepo = new TestImageMockRepository();
+        var imgRepo = TestHelper.CreateImageRepository();
         var id = Guid.NewGuid();
         await imgRepo.UploadImageAsync(id, "img.png", new MemoryStream(Encoding.UTF8.GetBytes("abc")), "text/plain");
 
@@ -160,7 +160,7 @@ public class EndpointTests
     public async Task GetImage_NotFound()
     {
         var repoManager = TestHelper.CreateRepositoryManager(out _);
-        var imgRepo = new TestImageMockRepository();
+        var imgRepo = TestHelper.CreateImageRepository();
         var ep = Factory.Create<GetImage>(c =>
         {
             c.AddTestServices(s =>
@@ -179,7 +179,7 @@ public class EndpointTests
     public async Task PostImage_Uploads_File()
     {
         var repoManager = TestHelper.CreateRepositoryManager(out _);
-        var imgRepo = new TestImageMockRepository();
+        var imgRepo = TestHelper.CreateImageRepository();
         var ep = Factory.Create<PostImage>(c =>
         {
             c.AddTestServices(s =>

--- a/MyWebApp.Tests/TestHelper.cs
+++ b/MyWebApp.Tests/TestHelper.cs
@@ -1,7 +1,12 @@
+using Amazon.Runtime;
+using Amazon.Runtime.Internal.Util;
+using Amazon.S3;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Model.Models;
 using Repository;
+using Repository.S3;
+using Contracts;
 
 namespace MyWebApp.Tests;
 
@@ -15,6 +20,19 @@ public static class TestHelper
         context = new TestDbContext(options);
         var configuration = new ConfigurationBuilder().Build();
         return new RepositoryManager(context, configuration);
+    }
+
+    public static ITestImageRepository CreateImageRepository(bool useMock = true)
+    {
+        if (useMock)
+        {
+            return new TestImageMockRepository();
+        }
+
+        var configuration = new ConfigurationBuilder().Build();
+        var s3Client = new AmazonS3Client(new AnonymousAWSCredentials(), new AmazonS3Config());
+        var logger = Logger.GetLogger(typeof(TestImageRepository));
+        return new TestImageRepository(s3Client, configuration, logger);
     }
 
 }

--- a/MyWebApp/Program.cs
+++ b/MyWebApp/Program.cs
@@ -10,7 +10,7 @@ bld.Services.AddEndpointsApiExplorer();
 bld.Services.AddSwaggerGen();
 bld.Services.AddScoped<OaDbContext>();
 bld.Services.AddScoped<RepositoryManager>();
-bld.Services.AddScoped<ITestImageRepository, TestImageMockRepository>();
+bld.Services.AddTestImageRepository(bld.Configuration);
 //bld.Services.AddSingleton<ILogger, MyWebApp.Logger>();
 
 var app = bld.Build();

--- a/Repository.S3/TestImageRepositoryServiceCollectionExtensions.cs
+++ b/Repository.S3/TestImageRepositoryServiceCollectionExtensions.cs
@@ -1,0 +1,22 @@
+using Contracts;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Repository.S3;
+
+public static class TestImageRepositoryServiceCollectionExtensions
+{
+    public static IServiceCollection AddTestImageRepository(this IServiceCollection services, IConfiguration configuration)
+    {
+        var useMock = configuration.GetValue<bool>("UseMockTestImageRepository", true);
+        if (useMock)
+        {
+            services.AddScoped<ITestImageRepository, TestImageMockRepository>();
+        }
+        else
+        {
+            services.AddScoped<ITestImageRepository, TestImageRepository>();
+        }
+        return services;
+    }
+}


### PR DESCRIPTION
## Summary
- provide service collection extension for choosing mock or real image repository
- allow tests to instantiate either repository via `TestHelper.CreateImageRepository`
- register image repository through extension method in `Program`
- update unit tests to use the helper

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ed86855ec832098c3d26471130f88